### PR TITLE
Uvvis blank substraction

### DIFF
--- a/baseclasses/chemical_energy/uvvismeasurementconcentration.py
+++ b/baseclasses/chemical_energy/uvvismeasurementconcentration.py
@@ -27,7 +27,7 @@ from nomad.datamodel.results import Results, Material
 from nomad.datamodel.metainfo.plot import PlotSection, PlotlyFigure
 import plotly.graph_objects as go
 
-from baseclasses.solar_energy import UVvisData, UVvisMeasurement
+from baseclasses.solar_energy import UVvisData
 from ..helper.utilities import get_reference
 
 
@@ -41,7 +41,7 @@ class UVvisDataConcentration(UVvisData, PlotSection):
         a_eln=dict(component='NumberEditQuantity', defaultDisplayUnit='ug/ml'))
 
     blank_substraction = Quantity(
-        type=Reference(UVvisMeasurement.m_def),
+        type=Reference(UVvisData.m_def),
         a_eln=dict(component='ReferenceEditQuantity'))
 
     calibration_measurement = Quantity(
@@ -138,7 +138,7 @@ class UVvisDataConcentration(UVvisData, PlotSection):
         if self.chemical_composition_or_formulas and self.peak_value and not self.calibration_measurement:
             blank_substraction_value = 0
             if self.blank_substraction is not None:
-                blank_substraction_value = self.blank_substraction.measurements[0].peak_value
+                blank_substraction_value = self.blank_substraction.peak_value
             concentration, self.reference = getConcentrationData(archive, logger,
                                                                  self.chemical_composition_or_formulas,
                                                                  self.peak_value - blank_substraction_value)

--- a/baseclasses/chemical_energy/uvvismeasurementconcentration.py
+++ b/baseclasses/chemical_energy/uvvismeasurementconcentration.py
@@ -27,7 +27,7 @@ from nomad.datamodel.results import Results, Material
 from nomad.datamodel.metainfo.plot import PlotSection, PlotlyFigure
 import plotly.graph_objects as go
 
-from baseclasses.solar_energy import UVvisData
+from baseclasses.solar_energy import UVvisData, UVvisMeasurement
 from ..helper.utilities import get_reference
 
 
@@ -39,6 +39,10 @@ class UVvisDataConcentration(UVvisData, PlotSection):
         type=np.dtype(np.float64),
         unit=('ug/ml'),
         a_eln=dict(component='NumberEditQuantity', defaultDisplayUnit='ug/ml'))
+
+    blank_substraction = Quantity(
+        type=Reference(UVvisMeasurement.m_def),
+        a_eln=dict(component='ReferenceEditQuantity'))
 
     calibration_measurement = Quantity(
         type=bool,
@@ -132,9 +136,12 @@ class UVvisDataConcentration(UVvisData, PlotSection):
             self.figures = [PlotlyFigure(label='figure 1', figure=fig.to_plotly_json())]
 
         if self.chemical_composition_or_formulas and self.peak_value and not self.calibration_measurement:
+            blank_substraction_value = 0
+            if self.blank_substraction is not None:
+                blank_substraction_value = self.blank_substraction.measurements[0].peak_value
             concentration, self.reference = getConcentrationData(archive, logger,
                                                                  self.chemical_composition_or_formulas,
-                                                                 self.peak_value)
+                                                                 self.peak_value - blank_substraction_value)
             if self.reference:
                 self.concentration = concentration
 

--- a/baseclasses/data_transformations/uvvisconcentrationdetection.py
+++ b/baseclasses/data_transformations/uvvisconcentrationdetection.py
@@ -25,7 +25,7 @@ from nomad.datamodel.metainfo.basesections import Analysis, SectionReference
 from nomad.datamodel.metainfo.plot import PlotSection, PlotlyFigure
 import plotly.graph_objects as go
 
-from baseclasses.solar_energy import UVvisMeasurement
+from baseclasses.solar_energy import UVvisMeasurement, UVvisData
 
 class UVvisReference(SectionReference):
     reference = Quantity(
@@ -44,7 +44,7 @@ class UVvisConcentrationDetection(Analysis, PlotSection):
         a_eln=dict(component='StringEditQuantity'))
 
     blank_substraction = Quantity(
-        type=Reference(UVvisMeasurement.m_def),
+        type=Reference(UVvisData.m_def),
         a_eln=dict(component='ReferenceEditQuantity'))
 
     minimum_peak_value = Quantity(
@@ -77,7 +77,7 @@ class UVvisConcentrationDetection(Analysis, PlotSection):
 
         blank_substraction_value = 0
         if self.blank_substraction is not None:
-            blank_substraction_value = self.blank_substraction.measurements[0].peak_value
+            blank_substraction_value = self.blank_substraction.peak_value
 
         for uvvis_reference in self.inputs:
             for uvvisdata in uvvis_reference.reference.measurements:


### PR DESCRIPTION
This PR adds the possibility to do a blank substraction to enable calibration despite different usages of the uvvis measurements. Now we support both types: blank substraction directly performed in the UVvis machine or afterwards in NOMAD.