### PR TITLE
Remove writing of sample ID to results section

### DIFF
--- a/src/baseclasses/chemical_energy/nome_cp_analysis.py
+++ b/src/baseclasses/chemical_energy/nome_cp_analysis.py
@@ -58,7 +58,8 @@ class CPOERAnalysisResult(AnalysisResult):
     experiment_duration = Quantity(type=np.dtype(np.float64), unit=('s'))
     reaction_type = Quantity(
         type=str,
-        description='At the moment only OER CP is supported. In the future maybe also NRR CP.',
+        description='At the moment only OER CP is supported.'
+                    'In the future maybe also NRR CP.',
     )
     voltage_shift = Quantity(
         links=['https://w3id.org/nfdi4cat/voc4cat_0007219'],
@@ -111,7 +112,7 @@ class CPAnalysis(Analysis):
             duration = input_obj.time[-1]
 
             # start a new group if the current density changes
-            # only group together if same current density is immediately following each other
+            # group together if same current density is immediately following each other
             if (
                 recent_group is None
                 or recent_group['current_density'] != current_density
@@ -190,7 +191,8 @@ def get_all_cp_in_upload(data_archive, upload_id):
     from nomad.search import search
 
     query = {
-        'section_defs.definition_qualified_name': 'baseclasses.chemical_energy.chronopotentiometry.Chronopotentiometry',
+        'section_defs.definition_qualified_name':
+            'baseclasses.chemical_energy.chronopotentiometry.Chronopotentiometry',
         'results.eln.methods': 'OER Chronopotentiometry',
         'upload_id': upload_id,
     }

--- a/src/baseclasses/chemical_energy/nome_cp_analysis.py
+++ b/src/baseclasses/chemical_energy/nome_cp_analysis.py
@@ -156,7 +156,7 @@ class CPAnalysis(Analysis):
 
         if self.inputs is not None and len(self.inputs) > 0:
             for sample in self.inputs[0].reference.samples:
-                export_lab_id(archive, sample.lab_id)
+                #export_lab_id(archive, sample.lab_id)
                 if sample.reference.chemical_composition_or_formulas is not None:
                     if not archive.results:
                         archive.results = Results()

--- a/src/baseclasses/chemical_energy/nome_cp_analysis.py
+++ b/src/baseclasses/chemical_energy/nome_cp_analysis.py
@@ -156,7 +156,6 @@ class CPAnalysis(Analysis):
 
         if self.inputs is not None and len(self.inputs) > 0:
             for sample in self.inputs[0].reference.samples:
-                #export_lab_id(archive, sample.lab_id)
                 if sample.reference.chemical_composition_or_formulas is not None:
                     if not archive.results:
                         archive.results = Results()


### PR DESCRIPTION
This PR fixes the problem that sample IDs exist multiple times when they become part of the CPAnalysis. The PR belongs to another PR in the chemical-energy repository https://github.com/nomad-hzb/nomad-chemical-energy/pull/61