### PR TITLE
Batch ids addon

### DIFF
--- a/src/baseclasses/__init__.py
+++ b/src/baseclasses/__init__.py
@@ -93,8 +93,6 @@ class Batch(Collection):
 
     batch_id = SubSection(section_def=ReadableIdentifiersCustom)
 
-    subbatch_id = SubSection(section_def=ReadableIdentifiersCustom)
-
     def normalize(self, archive, logger):
         super().normalize(archive, logger)
 

--- a/src/baseclasses/__init__.py
+++ b/src/baseclasses/__init__.py
@@ -93,6 +93,8 @@ class Batch(Collection):
 
     batch_id = SubSection(section_def=ReadableIdentifiersCustom)
 
+    subbatch_id = SubSection(section_def=ReadableIdentifiersCustom)
+
     def normalize(self, archive, logger):
         super().normalize(archive, logger)
 

--- a/src/baseclasses/helper/solar_cell_batch_mapping.py
+++ b/src/baseclasses/helper/solar_cell_batch_mapping.py
@@ -224,6 +224,11 @@ def map_batch(sample_ids, batch_id, upload_id, batch_class):
     return (batch_id, archive)
 
 
+def map_subbatch(sample_ids, subbatch_id, upload_id, subbatch_class):
+    """Create a subbatch archive grouping samples that share the same subbatch ID."""
+    return map_batch(sample_ids, subbatch_id, upload_id, subbatch_class)
+
+
 def map_annealing(data):
     annealing = Annealing()
     if get_value(data, 'IR annealing power [W]', None, unit='W') is not None:

--- a/src/baseclasses/helper/solar_cell_batch_mapping.py
+++ b/src/baseclasses/helper/solar_cell_batch_mapping.py
@@ -209,7 +209,7 @@ def map_basic_sample(data, substrate_name, upload_id, sample_class):
     return (data['Nomad ID'], archive)
 
 
-def map_batch(batch_ids, batch_id, upload_id, batch_class):
+def map_batch(sample_ids, batch_id, upload_id, batch_class):    
     archive = batch_class(
         name=batch_id,
         lab_id=batch_id,
@@ -218,7 +218,7 @@ def map_batch(batch_ids, batch_id, upload_id, batch_class):
                 reference=get_reference(upload_id, f'{lab_id}.archive.json'),
                 lab_id=lab_id,
             )
-            for lab_id in batch_ids
+            for lab_id in sample_ids
         ],
     )
     return (batch_id, archive)


### PR DESCRIPTION
the accompanying addition for the tfsc batch-subbatch resolution, merely adding a subbatch mapping function. 

The map_batch change is non consequential, just a 'typo' change to represent the intended parameter input.

Tests on Hysprint with this setup are passing, there should not be any issues. 
